### PR TITLE
additional instruction in chacha20poly1305 algo

### DIFF
--- a/specs/emip-003.md
+++ b/specs/emip-003.md
@@ -41,6 +41,7 @@ ChaCha20Poly1305 combines these together to give an algorithm that both encrypts
     1) Result of `PBKDF2` as the key
     1) A randomly-initialized 12-byte array as the nonce
     1) Tag size of 16 bytes
+    1) An empty *additional authenticated data* (AAD) field
 1) Return a byte array representing the concatenation of
     1) The salt
     1) The nonce


### PR DESCRIPTION
Just added an additional detail in the encryption spec (the additional authenticated data field should be an empty string).

See reference implementation: https://github.com/input-output-hk/js-cardano-wasm/blob/6582eae55641c523026729e78be36ae3caff9e73/cardano-wallet/src/lib.rs#L1463